### PR TITLE
Support React/jsx style comments by ignoring newline characters in the main regex.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ interface IPreprocessorOption {
   verbose: boolean;
 }
 
-const REGEX_DIRECTIVE = /\s*\/\/\s*#!(\w*)\s?\s*(.*)?/;
+const REGEX_DIRECTIVE = /[\t\f\v]*\/\/\s*#!(\w*)[\t\f\v]?[\t\f\v]*(.*)?/;
 
 const DEFAULT_OPTIONS: IPreprocessorOption = {
   debug: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ interface IPreprocessorOption {
   verbose: boolean;
 }
 
-const REGEX_DIRECTIVE = /[\t\f\v]*\/\/\s*#!(\w*)[\t\f\v]?[\t\f\v]*(.*)?/;
+const REGEX_DIRECTIVE = /[\t\f\v ]*\/\/\s*#!(\w*)[\t\f\v ]?[\t\f\v ]*(.*)?/;
 
 const DEFAULT_OPTIONS: IPreprocessorOption = {
   debug: false,


### PR DESCRIPTION
Hello. You've made a great plugin. It's exactly what I needed. Thank you.

When preprocessing a project using react,  adding a conditional block inside of a jsx expression causes a syntax error. The closing brace of the jsx comment gets removed with the block. Ignoring newline characters in the regex prevents this from happening.

Example Usage:
```jsx
const MyConditionalComponent = ()=> <MyComponent>
<div><h2>Hello </h2>

{/*
// #!if SAY_WORLD
*/}
                World!
{/*
// #!endif
*/}

</div>
</MyComponent>

```



